### PR TITLE
adds: REST API concept for Milestone 0.2 book concept

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,4 +37,4 @@ jobs:
         run: go build -v .
 
       - name: Test
-        run: go test -v .
+        run: go test -cover -v ./... 

--- a/src/backend/controllers/book.go
+++ b/src/backend/controllers/book.go
@@ -1,14 +1,14 @@
+/*
+Package controllers/books implements Book object CRUD patterns.
+*/
+
 package controllers
 
 import (
 	"errors"
-	"fmt"
-	"net/http"
-	"strconv"
-
-	"github.com/gin-gonic/gin"
 )
 
+// Book struct for Milestone 2, to be replaced with far grander models
 type Book struct {
 	ID      int    `json:"id"`
 	Name    string `json:"name"`
@@ -16,6 +16,8 @@ type Book struct {
 }
 
 // TODO: Development Mock DB
+
+// GenerateSampleBooks returns an array of predefined Books for testing usecases.
 func GenerateSampleBooks() []Book {
 	return []Book{
 		{
@@ -31,32 +33,22 @@ func GenerateSampleBooks() []Book {
 	}
 }
 
-/**
- * TODO: Seperate Controller logic from API Logic in main.go
- * Only controller logic should be here, such as handling structs etc.
- */
-// API
-func GetBooks(c *gin.Context) {
-	books := GenerateSampleBooks()
-	c.JSON(http.StatusOK, books)
+// GetBooks handles retrieving all Books from the DB and returning them to the server context
+func GetBooks() []Book {
+	return GenerateSampleBooks()
 }
 
-func GetBook(c *gin.Context) {
-	id, err := strconv.Atoi(c.Param("id"))
-
-	if err != nil {
-		c.Error(fmt.Errorf("Error converting id to int"))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err})
-	}
-
+// GetBook handles retrieving only the book with the corresponding id that matches the provided parameter
+func GetBook(id int) (Book, error) {
 	books := GenerateSampleBooks()
 
-	if len(books)-1 < id {
-		errorString := "Id provided is greater than book list"
-		c.Error(errors.New(errorString))
-		c.JSON(http.StatusNotFound, gin.H{"error": errorString})
-		return
+	if id < 0 {
+		return Book{}, errors.New("Invalid id provided")
 	}
 
-	c.JSON(http.StatusOK, books[id])
+	if len(books)-1 < id {
+		return Book{}, errors.New("Id provided is greater than book list")
+	}
+
+	return books[id], nil
 }

--- a/src/backend/controllers/book.go
+++ b/src/backend/controllers/book.go
@@ -1,0 +1,62 @@
+package controllers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+)
+
+type Book struct {
+	ID      int    `json:"id"`
+	Name    string `json:"name"`
+	Release int    `json:"release"`
+}
+
+// TODO: Development Mock DB
+func GenerateSampleBooks() []Book {
+	return []Book{
+		{
+			ID:      1,
+			Name:    "Harry Potter and the Sorcerers Stone",
+			Release: 1994,
+		},
+		{
+			ID:      2,
+			Name:    "Harry Potter and the Chamber of Secrets",
+			Release: 1998,
+		},
+	}
+}
+
+/**
+ * TODO: Seperate Controller logic from API Logic in main.go
+ * Only controller logic should be here, such as handling structs etc.
+ */
+// API
+func GetBooks(c *gin.Context) {
+	books := GenerateSampleBooks()
+	c.JSON(http.StatusOK, books)
+}
+
+func GetBook(c *gin.Context) {
+	id, err := strconv.Atoi(c.Param("id"))
+
+	if err != nil {
+		c.Error(fmt.Errorf("Error converting id to int"))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err})
+	}
+
+	books := GenerateSampleBooks()
+
+	if len(books)-1 < id {
+		errorString := "Id provided is greater than book list"
+		c.Error(errors.New(errorString))
+		c.JSON(http.StatusNotFound, gin.H{"error": errorString})
+		return
+	}
+
+	c.JSON(http.StatusOK, books[id])
+}

--- a/src/backend/controllers/book.go
+++ b/src/backend/controllers/book.go
@@ -15,18 +15,23 @@ type Book struct {
 	Release int    `json:"release"`
 }
 
+const (
+	errorInvalidID = "Invalid ID provided"
+	errorGreaterID = "Provided ID is greater than book list size"
+)
+
 // TODO: Development Mock DB
 
 // GenerateSampleBooks returns an array of predefined Books for testing usecases.
 func GenerateSampleBooks() []Book {
 	return []Book{
 		{
-			ID:      1,
+			ID:      0,
 			Name:    "Harry Potter and the Sorcerers Stone",
 			Release: 1994,
 		},
 		{
-			ID:      2,
+			ID:      1,
 			Name:    "Harry Potter and the Chamber of Secrets",
 			Release: 1998,
 		},
@@ -42,13 +47,37 @@ func GetBooks() []Book {
 func GetBook(id int) (Book, error) {
 	books := GenerateSampleBooks()
 
-	if id < 0 {
-		return Book{}, errors.New("Invalid id provided")
-	}
-
-	if len(books)-1 < id {
-		return Book{}, errors.New("Id provided is greater than book list")
+	if err := BookIDResolver(id); err != nil {
+		return Book{}, err
 	}
 
 	return books[id], nil
+}
+
+// DeleteBook handles removing the book with the corresponding Id from the datasource
+func DeleteBook(id int) ([]Book, error) {
+	books := GenerateSampleBooks()
+
+	if err := BookIDResolver(id); err != nil {
+		return []Book{}, err
+	}
+
+	return append(books[:id], books[id+1:]...), nil
+}
+
+// NOTE: This is a helper function while DB is not implemented
+
+// BookIDResolver handles row length handling while we are using index as id (TEMP)
+func BookIDResolver(id int) error {
+	books := GenerateSampleBooks()
+
+	if id < 0 {
+		return errors.New(errorInvalidID)
+	}
+
+	if len(books)-1 < id {
+		return errors.New(errorGreaterID)
+	}
+
+	return nil
 }

--- a/src/backend/controllers/book_test.go
+++ b/src/backend/controllers/book_test.go
@@ -1,0 +1,1 @@
+package controllers

--- a/src/backend/controllers/book_test.go
+++ b/src/backend/controllers/book_test.go
@@ -19,26 +19,54 @@ func TestGetBooks(t *testing.T) {
 	AssertExpected(t, expected, received)
 }
 
-func TestGetBookById(t *testing.T) {
+func TestGetBookByID(t *testing.T) {
 	collection := GenerateSampleBooks()
 
-	t.Run("Get By Valid Id", func(t *testing.T) {
+	t.Run("Get By Valid ID", func(t *testing.T) {
 		expected := collection[0]
 		received, _ := GetBook(0)
 
 		AssertExpected(t, expected, received)
 	})
 
-	t.Run("Get by Invalid Id", func(t *testing.T) {
+	t.Run("Get by Invalid ID", func(t *testing.T) {
 		_, err := GetBook(1000000)
 
-		AssertExpected(t, errors.New("Id provided is greater than book list"), err)
+		AssertExpected(t, errors.New("Provided ID is greater than book list size"), err)
 	})
 
-	t.Run("Get by Invalid Negative Id", func(t *testing.T) {
+	t.Run("Get by Invalid Negative ID", func(t *testing.T) {
 		_, err := GetBook(-1)
 
-		AssertExpected(t, errors.New("Invalid id provided"), err)
+		AssertExpected(t, errors.New("Invalid ID provided"), err)
+	})
+}
+
+func TestDeleteBookByID(t *testing.T) {
+	var expected = []Book{
+		{
+			ID:      1,
+			Name:    "Harry Potter and the Chamber of Secrets",
+			Release: 1998,
+		},
+	}
+
+	t.Run("Delete By Valid ID", func(t *testing.T) {
+		booklist, err := DeleteBook(0)
+
+		AssertExpected(t, nil, err)
+		AssertExpected(t, expected, booklist)
 	})
 
+	t.Run("Delete by Invalid ID", func(t *testing.T) {
+		_, err := DeleteBook(3)
+
+		AssertExpected(t, errors.New("Provided ID is greater than book list size"), err)
+	})
+
+	t.Run("Get by Invalid Negative ID", func(t *testing.T) {
+		_, err := DeleteBook(-1)
+
+		AssertExpected(t, errors.New("Invalid ID provided"), err)
+	})
 }

--- a/src/backend/controllers/book_test.go
+++ b/src/backend/controllers/book_test.go
@@ -1,1 +1,44 @@
 package controllers
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func AssertExpected(t *testing.T, expected, received interface{}) {
+	if !reflect.DeepEqual(expected, received) {
+		t.Errorf("Got %v, wanted %v", received, expected)
+	}
+}
+
+func TestGetBooks(t *testing.T) {
+	expected := GenerateSampleBooks()
+	received := GetBooks()
+
+	AssertExpected(t, expected, received)
+}
+
+func TestGetBookById(t *testing.T) {
+	collection := GenerateSampleBooks()
+
+	t.Run("Get By Valid Id", func(t *testing.T) {
+		expected := collection[0]
+		received, _ := GetBook(0)
+
+		AssertExpected(t, expected, received)
+	})
+
+	t.Run("Get by Invalid Id", func(t *testing.T) {
+		_, err := GetBook(1000000)
+
+		AssertExpected(t, errors.New("Id provided is greater than book list"), err)
+	})
+
+	t.Run("Get by Invalid Negative Id", func(t *testing.T) {
+		_, err := GetBook(-1)
+
+		AssertExpected(t, errors.New("Invalid id provided"), err)
+	})
+
+}

--- a/src/backend/main.go
+++ b/src/backend/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"Golang/Athenaeum/src/backend/controllers"
-	"fmt"
 	"net/http"
 	"strconv"
 
@@ -16,7 +15,6 @@ func main() {
 
 // ErrorHandler provides basic error handling between the front-end and back-end
 func ErrorHandler(c *gin.Context, err error, status int) {
-	c.Error(fmt.Errorf(err.Error()))
 	c.JSON(status, gin.H{"error": err.Error()})
 }
 
@@ -34,6 +32,7 @@ func SetupRouter() *gin.Engine {
 	router.GET("/book/", func(c *gin.Context) {
 		c.JSON(http.StatusOK, controllers.GetBooks())
 	})
+
 	router.GET("/book/:id", func(c *gin.Context) {
 		id, err := strconv.Atoi(c.Param("id"))
 
@@ -51,6 +50,24 @@ func SetupRouter() *gin.Engine {
 
 		c.JSON(http.StatusOK, book)
 
+	})
+
+	router.DELETE("/book/:id", func(c *gin.Context) {
+		id, err := strconv.Atoi(c.Param("id"))
+
+		if err != nil {
+			ErrorHandler(c, err, http.StatusInternalServerError)
+			return
+		}
+
+		books, err := controllers.DeleteBook(id)
+
+		if err != nil {
+			ErrorHandler(c, err, http.StatusNotFound)
+			return
+		}
+
+		c.JSON(http.StatusOK, books)
 	})
 
 	return router

--- a/src/backend/main.go
+++ b/src/backend/main.go
@@ -1,6 +1,10 @@
 package main
 
-import "github.com/gin-gonic/gin"
+import (
+	"Golang/Athenaeum/src/backend/controllers"
+
+	"github.com/gin-gonic/gin"
+)
 
 func main() {
 	router := SetupRouter()
@@ -16,6 +20,9 @@ func SetupRouter() *gin.Engine {
 			"message": "Hello, World!",
 		})
 	})
+
+	router.GET("/book/", controllers.GetBooks)
+	router.GET("/book/:id", controllers.GetBook)
 
 	return router
 }

--- a/src/backend/main_test.go
+++ b/src/backend/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"Golang/Athenaeum/src/backend/controllers"
+
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +12,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func setup() {
+
+}
+
+// Referencing https://medium.com/@craigchilds94/testing-gin-json-responses-1f258ce3b0b1
 func performRequest(r http.Handler, method, path string) *httptest.ResponseRecorder {
 	req, _ := http.NewRequest(method, path, nil)
 	w := httptest.NewRecorder()
@@ -23,19 +30,70 @@ func TestHelloWorld(t *testing.T) {
 		"message": "Hello, World!",
 	}
 
-	// Grab our router
-	router := SetupRouter()                 // Perform a GET request with that handler.
-	w := performRequest(router, "GET", "/") // Assert we encoded correctly,
+	router := SetupRouter()
+	w := performRequest(router, "GET", "/")
 
-	// the request gives a 200
-	assert.Equal(t, http.StatusOK, w.Code) // Convert the JSON response to a map
+	assert.Equal(t, http.StatusOK, w.Code)
 
 	var response map[string]string
-	err := json.Unmarshal([]byte(w.Body.String()), &response) // Grab the value & whether or not it exists
+	err := json.Unmarshal([]byte(w.Body.String()), &response)
 
-	value, exists := response["message"] // Make some assertions on the correctness of the response.
+	// Make some assertions on the correctness of the response.
+	value, exists := response["message"]
 
 	assert.Nil(t, err)
 	assert.True(t, exists)
 	assert.Equal(t, body["message"], value)
+}
+
+func TestBookCRUD(t *testing.T) {
+	router := SetupRouter()
+
+	// Redundant using same source, but this is while we don't have Mock DB connection
+	collection := controllers.GenerateSampleBooks()
+
+	t.Run("GET All", func(t *testing.T) {
+		w := performRequest(router, "GET", "/book/")
+
+		// Assert we encoded correctly,
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// Convert the JSON response to struct
+		var response []controllers.Book
+		err := json.Unmarshal([]byte(w.Body.String()), &response)
+
+		assert.Nil(t, err)
+		assert.Equal(t, collection, response)
+	})
+
+	t.Run("GET By Valid Id", func(t *testing.T) {
+		w := performRequest(router, "GET", "/book/0")
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response controllers.Book
+		err := json.Unmarshal([]byte(w.Body.String()), &response)
+
+		assert.Nil(t, err)
+		assert.Equal(t, collection[0], response)
+	})
+
+	t.Run("GET by Invalid Id", func(t *testing.T) {
+		w := performRequest(router, "GET", "/book/3")
+		assert.Equal(t, http.StatusNotFound, w.Code)
+
+		type errResponse struct {
+			Error   string `json:"error"`
+			Context string `json:"context"`
+		}
+
+		var response errResponse
+		var expectedMessage = errResponse{
+			Error: "Id provided is greater than book list",
+		}
+
+		err := json.Unmarshal([]byte(w.Body.String()), &response)
+
+		assert.Nil(t, err)
+		assert.Equal(t, expectedMessage, response)
+	})
 }

--- a/src/backend/main_test.go
+++ b/src/backend/main_test.go
@@ -12,10 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func setup() {
-
-}
-
 // Referencing https://medium.com/@craigchilds94/testing-gin-json-responses-1f258ce3b0b1
 func performRequest(r http.Handler, method, path string) *httptest.ResponseRecorder {
 	req, _ := http.NewRequest(method, path, nil)


### PR DESCRIPTION
Fixes #22

This adds the following endpoints, with there respective tests: 
- `GET` /book
- `GET` /book/:id
- `DELETE` /book/:id

Furthermore, this also adds the `/controllers` directory in the back-end which provides a read-only makeshift (waiting on #21 to extend this) DB structure for coupling database operations to the server.