### PR TITLE
adds: SQLite and GORM integration with REST API for Books Endpoint

### DIFF
--- a/src/backend/controllers/book.go
+++ b/src/backend/controllers/book.go
@@ -20,7 +20,7 @@ func FindBooks(c *gin.Context) {
 	var books []models.Book
 	db.Find(&books)
 
-	c.JSON(http.StatusOK, gin.H{"data": books})
+	c.JSON(http.StatusOK, books)
 }
 
 // CreateBook called by POST /books

--- a/src/backend/controllers/book.go
+++ b/src/backend/controllers/book.go
@@ -12,6 +12,16 @@ const (
 	errRecordNotFound = "Record not found!"
 )
 
+// RetrieveBookByID is a helper function which returns a boolean based on success to find book
+func RetrieveBookByID(db *gorm.DB, c *gin.Context, book *models.Book) bool {
+	if err := db.Where("id = ?", c.Param("id")).First(&book).Error; err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Record not found!"})
+		return false
+	}
+
+	return true
+}
+
 // FindBooks called by GET /books
 // Get all books
 func FindBooks(c *gin.Context) {
@@ -49,8 +59,8 @@ func FindBook(c *gin.Context) {
 
 	// Get model if exist
 	var book models.Book
-	if err := db.Where("id = ?", c.Param("id")).First(&book).Error; err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Record not found!"})
+
+	if !RetrieveBookByID(db, c, &book) {
 		return
 	}
 
@@ -64,8 +74,7 @@ func UpdateBook(c *gin.Context) {
 
 	// Get model if exist
 	var book models.Book
-	if err := db.Where("id = ?", c.Param("id")).First(&book).Error; err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Record not found!"})
+	if !RetrieveBookByID(db, c, &book) {
 		return
 	}
 
@@ -88,8 +97,7 @@ func DeleteBook(c *gin.Context) {
 
 	// Get model if exist
 	var book models.Book
-	if err := db.Where("id = ?", c.Param("id")).First(&book).Error; err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Record not found!"})
+	if !RetrieveBookByID(db, c, &book) {
 		return
 	}
 

--- a/src/backend/go.mod
+++ b/src/backend/go.mod
@@ -4,5 +4,6 @@ go 1.14
 
 require (
 	github.com/gin-gonic/gin v1.6.2
+	github.com/jinzhu/gorm v1.9.12
 	github.com/stretchr/testify v1.5.1
 )

--- a/src/backend/main.go
+++ b/src/backend/main.go
@@ -37,7 +37,7 @@ func SetupRouter(dbTarget string) (*gin.Engine, *gorm.DB) {
 	})
 
 	router.GET("/books/", controllers.FindBooks)
-	router.POST("/books", controllers.CreateBook)
+	router.POST("/books/", controllers.CreateBook)
 	router.GET("/books/:id", controllers.FindBook)
 	router.PATCH("/books/:id", controllers.UpdateBook)
 	router.DELETE("/books/:id", controllers.DeleteBook)

--- a/src/backend/main.go
+++ b/src/backend/main.go
@@ -2,26 +2,33 @@ package main
 
 import (
 	"Golang/Athenaeum/src/backend/controllers"
-	"net/http"
-	"strconv"
+	"Golang/Athenaeum/src/backend/models"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jinzhu/gorm"
 )
 
 func main() {
-	router := SetupRouter()
+	// Configure the back-end router
+	router, db := SetupRouter("local.db")
+	defer db.Close()
+
 	router.Run(":3000")
 }
 
-// ErrorHandler provides basic error handling between the front-end and back-end
-func ErrorHandler(c *gin.Context, err error, status int) {
-	c.JSON(status, gin.H{"error": err.Error()})
-}
-
 // SetupRouter defines the routes and controllers which power our backend API
-func SetupRouter() *gin.Engine {
-
+func SetupRouter(dbTarget string) (*gin.Engine, *gorm.DB) {
+	//
 	router := gin.Default()
+
+	// Create SQLite Database if it doesn't exist
+	db := models.SetupModels(dbTarget)
+
+	// Provide db variable to controllers
+	router.Use(func(c *gin.Context) {
+		c.Set("db", db)
+		c.Next()
+	})
 
 	router.GET("/", func(c *gin.Context) {
 		c.JSON(200, gin.H{
@@ -29,46 +36,11 @@ func SetupRouter() *gin.Engine {
 		})
 	})
 
-	router.GET("/book/", func(c *gin.Context) {
-		c.JSON(http.StatusOK, controllers.GetBooks())
-	})
+	router.GET("/books/", controllers.FindBooks)
+	router.POST("/books", controllers.CreateBook)
+	router.GET("/books/:id", controllers.FindBook)
+	router.PATCH("/books/:id", controllers.UpdateBook)
+	router.DELETE("/books/:id", controllers.DeleteBook)
 
-	router.GET("/book/:id", func(c *gin.Context) {
-		id, err := strconv.Atoi(c.Param("id"))
-
-		if err != nil {
-			ErrorHandler(c, err, http.StatusInternalServerError)
-			return
-		}
-
-		book, err := controllers.GetBook(id)
-
-		if err != nil {
-			ErrorHandler(c, err, http.StatusNotFound)
-			return
-		}
-
-		c.JSON(http.StatusOK, book)
-
-	})
-
-	router.DELETE("/book/:id", func(c *gin.Context) {
-		id, err := strconv.Atoi(c.Param("id"))
-
-		if err != nil {
-			ErrorHandler(c, err, http.StatusInternalServerError)
-			return
-		}
-
-		books, err := controllers.DeleteBook(id)
-
-		if err != nil {
-			ErrorHandler(c, err, http.StatusNotFound)
-			return
-		}
-
-		c.JSON(http.StatusOK, books)
-	})
-
-	return router
+	return router, db
 }

--- a/src/backend/main_test.go
+++ b/src/backend/main_test.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"Golang/Athenaeum/src/backend/controllers"
-
+	"Golang/Athenaeum/src/backend/models"
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -20,18 +20,14 @@ func performRequest(r http.Handler, method, path string) *httptest.ResponseRecor
 	return w
 }
 
-type errResponse struct {
-	Error   string `json:"error"`
-	Context string `json:"context"`
-}
-
 func TestHelloWorld(t *testing.T) {
 	// Build our expected body
 	body := gin.H{
 		"message": "Hello, World!",
 	}
 
-	router := SetupRouter()
+	router, db := SetupRouter("test.db")
+	defer db.Close()
 	w := performRequest(router, "GET", "/")
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -45,115 +41,149 @@ func TestHelloWorld(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, exists)
 	assert.Equal(t, body["message"], value)
+
 }
 
-func TestBookCRUD(t *testing.T) {
-	router := SetupRouter()
+func TestBooksCRUD(t *testing.T) {
+	dbTarget := "test.db"
+	router, db := SetupRouter(dbTarget)
+	db.DropTableIfExists(&models.Book{}, "books")
+	db = models.SetupModels(dbTarget)
 
-	// Redundant using same source, but this is while we don't have Mock DB connection
-	collection := controllers.GenerateSampleBooks()
+	defer db.Close()
 
-	t.Run("GET All", func(t *testing.T) {
-		w := performRequest(router, "GET", "/book/")
+	t.Run("Create Empty DB", func(t *testing.T) {
+		w := performRequest(router, "GET", "/books/")
 
-		// Assert we encoded correctly,
 		assert.Equal(t, http.StatusOK, w.Code)
-
-		// Convert the JSON response to struct
-		var response []controllers.Book
-		err := json.Unmarshal([]byte(w.Body.String()), &response)
-
-		assert.Nil(t, err)
-		assert.Equal(t, collection, response)
 	})
 
-	t.Run("GET By Valid ID", func(t *testing.T) {
-		w := performRequest(router, "GET", "/book/0")
-		assert.Equal(t, http.StatusOK, w.Code)
+	t.Run("Retrieve Nonexistent ID on Empty DB", func(t *testing.T) {
 
-		var response controllers.Book
-		err := json.Unmarshal([]byte(w.Body.String()), &response)
+		w := performRequest(router, "GET", "/book/2")
 
-		assert.Nil(t, err)
-		assert.Equal(t, collection[0], response)
-	})
-
-	t.Run("GET by Invalid ID", func(t *testing.T) {
-		w := performRequest(router, "GET", "/book/3")
 		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
 
-		var response errResponse
-		var expectedMessage = errResponse{
-			Error: "Provided ID is greater than book list size",
+	t.Run("Populate DB with Harry Potter Set", func(t *testing.T) {
+		books := []string{
+			"Harry Potter and The Philosopher's Stone",
+			"Harry Potter and The Chamber of Secrets",
+			"Harry Potter and The Prisoner of Azkaban",
+			"Harry Potter and The Goblet of Fire",
+			"Harry Potter and The Order of The Phoenix",
+			"Harry Potter and The Half-Blood Prince",
+			"Harry Potter and The Deathly Hallows",
 		}
 
+		for _, book := range books {
+
+			payload, _ := json.Marshal(models.CreateBookInput{
+				Author: "J. K. Rowling",
+				Title:  book,
+			})
+
+			req, err := http.NewRequest("POST", "/books", bytes.NewReader(payload))
+			req.Header.Set("Content-Type", "application/json")
+
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, nil, err)
+			assert.Equal(t, http.StatusOK, w.Code)
+		}
+	})
+
+	t.Run("Retrieve Existing ID on Populated DB", func(t *testing.T) {
+		w := performRequest(router, "GET", "/books/2")
+
+		expected := models.Book{
+			Author: "J. K. Rowling",
+			ID:     2,
+			Title:  "Harry Potter and The Chamber of Secrets",
+		}
+
+		var response models.Book
 		err := json.Unmarshal([]byte(w.Body.String()), &response)
 
 		assert.Nil(t, err)
-		assert.Equal(t, expectedMessage, response)
-	})
-
-	t.Run("GET by Invalid Negative ID", func(t *testing.T) {
-		w := performRequest(router, "GET", "/book/-2")
-		assert.Equal(t, http.StatusNotFound, w.Code)
-
-		var response errResponse
-		var expectedMessage = errResponse{
-			Error: "Invalid ID provided",
-		}
-
-		err := json.Unmarshal([]byte(w.Body.String()), &response)
-
-		assert.Nil(t, err)
-		assert.Equal(t, expectedMessage, response)
-	})
-
-	t.Run("DELETE by valid ID", func(t *testing.T) {
-		w := performRequest(router, "DELETE", "/book/0")
 		assert.Equal(t, http.StatusOK, w.Code)
-
-		var response []controllers.Book
-		var expected = []controllers.Book{
-			{
-				ID:      1,
-				Name:    "Harry Potter and the Chamber of Secrets",
-				Release: 1998,
-			},
-		}
-
-		err := json.Unmarshal([]byte(w.Body.String()), &response)
-
-		assert.Nil(t, err)
 		assert.Equal(t, expected, response)
 	})
 
-	t.Run("DELETE by Invalid Negative ID", func(t *testing.T) {
-		w := performRequest(router, "DELETE", "/book/-1")
-		assert.Equal(t, http.StatusNotFound, w.Code)
+	t.Run("Attempt Updating Non-Existing ID", func(t *testing.T) {
+		w := performRequest(router, "PATCH", "/books/-2")
 
-		var response errResponse
-		var expected = errResponse{
-			Error: "Invalid ID provided",
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, "{\"error\":\"Record not found!\"}", w.Body.String())
+	})
+
+	t.Run("Updated Existing ID with Invalid Values", func(t *testing.T) {
+		payload, _ := json.Marshal(map[int]string{
+			2: "Harry Potter",
+			3: "JK Rowling",
+			4: "22",
+		})
+
+		req, err := http.NewRequest("PATCH", "/books/-2", bytes.NewReader(payload))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, nil, err)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Update Existing ID on Populated DB", func(t *testing.T) {
+		payload, _ := json.Marshal(models.UpdateBookInput{
+			Author: "J. K. Rowling",
+			Title:  "Harry Potter and The Gaslight Anthem",
+		})
+
+		req, err := http.NewRequest("PATCH", "/books/6", bytes.NewReader(payload))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, nil, err)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("Get Updated Book from Populated DB", func(t *testing.T) {
+		expected := models.Book{
+			Author: "J. K. Rowling",
+			Title:  "Harry Potter and The Gaslight Anthem",
+			ID:     6,
 		}
 
+		w := performRequest(router, "GET", "/books/6")
+
+		var response models.Book
 		err := json.Unmarshal([]byte(w.Body.String()), &response)
 
 		assert.Nil(t, err)
+		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, expected, response)
 	})
 
-	t.Run("DELETE by invalid ID", func(t *testing.T) {
-		w := performRequest(router, "DELETE", "/book/3")
+	t.Run("Delete Invalid Book from Populated DB", func(t *testing.T) {
+		w := performRequest(router, "DELETE", "/books/-1")
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("Delete Without ID Book from Populated DB", func(t *testing.T) {
+		w := performRequest(router, "DELETE", "/books/")
 		assert.Equal(t, http.StatusNotFound, w.Code)
+		assert.Equal(t, "404 page not found", w.Body.String())
+	})
 
-		var response errResponse
-		var expected = errResponse{
-			Error: "Provided ID is greater than book list size",
-		}
+	t.Run("Delete valid Book from Populated DB", func(t *testing.T) {
+		w := performRequest(router, "DELETE", "/books/6")
 
-		err := json.Unmarshal([]byte(w.Body.String()), &response)
-
-		assert.Nil(t, err)
-		assert.Equal(t, expected, response)
+		assert.Equal(t, "{\"data\":true}", w.Body.String())
+		assert.Equal(t, http.StatusOK, w.Code)
 	})
 }

--- a/src/backend/main_test.go
+++ b/src/backend/main_test.go
@@ -138,8 +138,7 @@ func TestBooksCRUD(t *testing.T) {
 
 	t.Run("Update Existing ID on Populated DB", func(t *testing.T) {
 		payload, _ := json.Marshal(models.UpdateBookInput{
-			Author: "J. K. Rowling",
-			Title:  "Harry Potter and The Gaslight Anthem",
+			Title: "Harry Potter and The Weird Sisters",
 		})
 
 		req, err := http.NewRequest("PATCH", "/books/6", bytes.NewReader(payload))
@@ -155,7 +154,7 @@ func TestBooksCRUD(t *testing.T) {
 	t.Run("Get Updated Book from Populated DB", func(t *testing.T) {
 		expected := models.Book{
 			Author: "J. K. Rowling",
-			Title:  "Harry Potter and The Gaslight Anthem",
+			Title:  "Harry Potter and The Weird Sisters",
 			ID:     6,
 		}
 

--- a/src/backend/main_test.go
+++ b/src/backend/main_test.go
@@ -28,6 +28,7 @@ func TestHelloWorld(t *testing.T) {
 
 	router, db := SetupRouter("test.db")
 	defer db.Close()
+
 	w := performRequest(router, "GET", "/")
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -83,7 +84,7 @@ func TestBooksCRUD(t *testing.T) {
 				Title:  book,
 			})
 
-			req, err := http.NewRequest("POST", "/books", bytes.NewReader(payload))
+			req, err := http.NewRequest("POST", "/books/", bytes.NewReader(payload))
 			req.Header.Set("Content-Type", "application/json")
 
 			w := httptest.NewRecorder()

--- a/src/backend/models/book.go
+++ b/src/backend/models/book.go
@@ -1,0 +1,17 @@
+package models
+
+type Book struct {
+	ID     uint   `json:"id" gorm:"primary_key"`
+	Title  string `json:"title"`
+	Author string `json:"author"`
+}
+
+type CreateBookInput struct {
+	Title  string `json:"title" binding:"required"`
+	Author string `json:"author" binding:"required"`
+}
+
+type UpdateBookInput struct {
+	Title  string `json:"title"`
+	Author string `json:"author"`
+}

--- a/src/backend/models/book.go
+++ b/src/backend/models/book.go
@@ -1,16 +1,19 @@
 package models
 
+// Book is the internal DB structure
 type Book struct {
 	ID     uint   `json:"id" gorm:"primary_key"`
 	Title  string `json:"title"`
 	Author string `json:"author"`
 }
 
+// CreateBookInput is the JSON binding validation handler
 type CreateBookInput struct {
 	Title  string `json:"title" binding:"required"`
 	Author string `json:"author" binding:"required"`
 }
 
+// UpdateBookInput is the JSON binding validation handler
 type UpdateBookInput struct {
 	Title  string `json:"title"`
 	Author string `json:"author"`

--- a/src/backend/models/setup.go
+++ b/src/backend/models/setup.go
@@ -2,9 +2,10 @@ package models
 
 import (
 	"github.com/jinzhu/gorm"
-	_ "github.com/jinzhu/gorm/dialects/sqlite"
+	_ "github.com/jinzhu/gorm/dialects/sqlite" //SQLite Driver
 )
 
+// SetupModels handles creation of DB Tables
 func SetupModels(dbTarget string) *gorm.DB {
 	db, err := gorm.Open("sqlite3", dbTarget)
 

--- a/src/backend/models/setup.go
+++ b/src/backend/models/setup.go
@@ -1,0 +1,18 @@
+package models
+
+import (
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+)
+
+func SetupModels(dbTarget string) *gorm.DB {
+	db, err := gorm.Open("sqlite3", dbTarget)
+
+	if err != nil {
+		panic("Failed to connect to database!")
+	}
+
+	db.AutoMigrate(&Book{})
+
+	return db
+}


### PR DESCRIPTION
Closes #32 #21

This adds the `Book` model, along with the helper validation models `UpdateBook`, and `CreateBook`, along with complete CRUD capabilities via GORM and SQLite3.

How to test:
- Run the backend either in a container, or using `go run .`
- Hit `localhost:3000/books/`  for getting all books
- Hit `localhost:3000/books/1` for getting a book by id
- Submit a  PATCH request to the same endpoint to modify.
- Submit a Delete to remove the entry
- Submit a POST to `localhost:3000/books` with the correct body to add  anew one.