### PR TITLE
add #20 - Add Semantic UI to Front-end

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -8,9 +8,11 @@
     "@testing-library/user-event": "^7.2.1",
     "eslint": "^6.8.0",
     "eslint-plugin-react": "^7.19.0",
+    "fomantic-ui-css": "^2.8.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-scripts": "3.4.1"
+    "react-scripts": "3.4.1",
+    "semantic-ui-react": "^0.88.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/frontend/src/App.js
+++ b/src/frontend/src/App.js
@@ -1,10 +1,19 @@
 import React from 'react';
+
+import 'fomantic-ui-css/semantic.css';
+import { Container, Header } from 'semantic-ui-react';
 import './App.css';
 
 function App() {
   return (
     <div className="App">
       <header className="App-header">
+        <Container>
+          <Header className="yellow">
+            Athenaeum
+          </Header>
+        </Container>
+
         <p>Hello World!</p>
       </header>
     </div>


### PR DESCRIPTION
Adding semantic-UI to the front end.

Example in app.js to show how to implement. 

CSS file only needs to be imported once. 